### PR TITLE
Implement CoroutineStubFactory

### DIFF
--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -94,6 +94,11 @@
 			<artifactId>proto-google-common-protos</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-kotlin-stub</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.salesforce.servicelibs</groupId>
 			<artifactId>reactor-grpc-stub</artifactId>
 			<optional>true</optional>

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/CoroutineStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/CoroutineStubFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+package org.springframework.grpc.client;
+
+import java.util.function.Supplier;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.kotlin.AbstractCoroutineStub;
+
+public class CoroutineStubFactory implements StubFactory<AbstractCoroutineStub<?>> {
+
+	@Override
+	public AbstractCoroutineStub<?> create(Supplier<ManagedChannel> channel,
+			Class<? extends AbstractCoroutineStub<?>> type) {
+		try {
+			return type.getConstructor(Channel.class, CallOptions.class)
+				.newInstance(channel.get(), CallOptions.DEFAULT);
+
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to create stub", e);
+		}
+	}
+
+	protected static boolean supports(Class<?> type) {
+		return AbstractCoroutineStub.class.isAssignableFrom(type);
+	}
+
+}

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.AbstractStub;
+import io.grpc.kotlin.AbstractCoroutineStub;
 
 public class GrpcClientFactoryTests {
 
@@ -88,6 +89,16 @@ public class GrpcClientFactoryTests {
 		assertThat(factory.getClient("local", OtherStub.class, null)).isNotNull();
 	}
 
+	@Test
+	void testCoroutineStubFactory() {
+		context.registerBean(CoroutineStubFactory.class, CoroutineStubFactory::new);
+		GrpcClientFactory.register(context,
+				GrpcClientRegistrationSpec.of("local")
+					.factory(CoroutineStubFactory.class)
+					.types(MyCoroutineStub.class));
+		assertThat(factory.getClient("local", MyCoroutineStub.class, null)).isNotNull();
+	}
+
 	static class OtherStubFactory implements StubFactory<OtherStub> {
 
 		@Override
@@ -131,6 +142,19 @@ public class GrpcClientFactoryTests {
 				return new MyStub(channel);
 			}
 
+		}
+
+	}
+
+	static class MyCoroutineStub extends AbstractCoroutineStub<MyCoroutineStub> {
+
+		public MyCoroutineStub(Channel channel, CallOptions callOptions) {
+			super(channel, callOptions);
+		}
+
+		@Override
+		protected MyCoroutineStub build(Channel channel, CallOptions callOptions) {
+			return new MyCoroutineStub(channel, callOptions);
 		}
 
 	}

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -50,6 +50,7 @@
 
 	<properties>
 		<grpc.version>1.72.0</grpc.version>
+		<grpc-kotlin.version>1.4.3</grpc-kotlin.version>
 		<protobuf-java.version>4.30.2</protobuf-java.version>
 		<google-common-protos.version>2.54.1</google-common-protos.version>
 		<micrometer.version>1.13.6</micrometer.version>
@@ -100,6 +101,11 @@
 				<version>${grpc.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.grpc</groupId>
+				<artifactId>grpc-kotlin-stub</artifactId>
+				<version>${grpc-kotlin.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.protobuf</groupId>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -142,6 +142,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-kotlin-stub</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
 			<optional>true</optional>

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -18,13 +18,16 @@ package org.springframework.grpc.autoconfigure.client;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration;
 import org.springframework.grpc.client.ChannelCredentialsProvider;
+import org.springframework.grpc.client.CoroutineStubFactory;
 import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
 
 import io.grpc.CompressorRegistry;
@@ -69,6 +72,18 @@ public class GrpcClientAutoConfiguration {
 	@Bean
 	ChannelBuilderCustomizers channelBuilderCustomizers(ObjectProvider<GrpcChannelBuilderCustomizer<?>> customizers) {
 		return new ChannelBuilderCustomizers(customizers.orderedStream().toList());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(name = "io.grpc.kotlin.AbstractCoroutineStub")
+	static class GrpcClientCoroutineStubConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		CoroutineStubFactory coroutineStubFactory() {
+			return new CoroutineStubFactory();
+		}
+
 	}
 
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
@@ -50,6 +50,7 @@ import io.grpc.Codec;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.kotlin.AbstractCoroutineStub;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.AbstractStub;
 
@@ -71,6 +72,14 @@ class GrpcClientAutoConfigurationTests {
 		this.contextRunner()
 			.withClassLoader(new FilteredClassLoader(AbstractStub.class))
 			.run((context) -> assertThat(context).doesNotHaveBean(GrpcClientAutoConfiguration.class));
+	}
+
+	@Test
+	void whenGrpcKotlinIsNotOnClasspathThenAutoConfigurationIsSkipped() {
+		this.contextRunner()
+			.withClassLoader(new FilteredClassLoader(AbstractCoroutineStub.class))
+			.run((context) -> assertThat(context)
+				.doesNotHaveBean(GrpcClientAutoConfiguration.GrpcClientCoroutineStubConfiguration.class));
 	}
 
 	@Test


### PR DESCRIPTION
Following up #170 

Here is an implementation of `CoroutineStubFactory` useful for kotlin projects. First, I [implemented](https://github.com/genuss/spring-grpc/tree/coroutine-stub-factory-separtate-module) it in a separate module, as I was proposing in the original issue #170. However I it seems like an overkill at the moment. The only additional dependency is `grpc-kotlin-stub` which may safely be optional just like `reactor-grpc-stub`.

The factory is created as a bean if `grpc-kotlin-stub` is on a classpath. The alternative would be to put it into `GrpcClientFactory#DEFAULT_FACTORIES`, but I don't feel working around classpath issues in that class. Please correct me if you feel it's better to put it there.

I feel, I'd better add a `RuntimeHintsRegistrar` for creating coroutine stubs, but I could find one for standard ones. Is it actually done somewhere now?