### PR TITLE
Update to Spring Boot 3.5.0

### DIFF
--- a/.github/workflows/check-samples.yml
+++ b/.github/workflows/check-samples.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - javaVersion: 17
-            springBootVersion: "3.4.5"
+            springBootVersion: "3.5.0"
           - javaVersion: 17
             springBootVersion: "3.5.0-SNAPSHOT"
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,9 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- internal dependencies -->
-		<spring-boot.version>3.4.5</spring-boot.version>
-		<jackson.version>2.17.2</jackson.version>
-		<junit.version>5.10.5</junit.version>
+		<spring-boot.version>3.5.0</spring-boot.version>
+		<jackson.version>2.19.0</jackson.version>
+		<junit.version>5.12.2</junit.version>
 		<assertj.version>3.27.3</assertj.version>
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>

--- a/samples/grpc-client/README.md
+++ b/samples/grpc-client/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 ...
 2025-02-27T09:21:19.515Z  INFO 1211091 --- [grpc-client] [           main] o.s.g.sample.GrpcClientApplication  : Started GrpcClientApplication in 0.909 seconds (process running for 1.172)

--- a/samples/grpc-client/build.gradle
+++ b/samples/grpc-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
+	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'com.google.protobuf' version '0.9.4'
 }

--- a/samples/grpc-client/pom.xml
+++ b/samples/grpc-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-oauth2/README.md
+++ b/samples/grpc-oauth2/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:test-run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 ...
 2022-12-08T05:32:25.427-08:00  INFO 551632 --- [           main] g.s.a.GrpcServerFactoryAutoConfiguration : Detected grpc-netty: Creating NettyGrpcServerFactory

--- a/samples/grpc-oauth2/build.gradle
+++ b/samples/grpc-oauth2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
+	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'org.graalvm.buildtools.native' version '0.10.3'
 	id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-oauth2/pom.xml
+++ b/samples/grpc-oauth2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-reactive/README.md
+++ b/samples/grpc-reactive/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"

--- a/samples/grpc-reactive/build.gradle
+++ b/samples/grpc-reactive/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-reactive/pom.xml
+++ b/samples/grpc-reactive/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-secure/README.md
+++ b/samples/grpc-secure/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"

--- a/samples/grpc-secure/build.gradle
+++ b/samples/grpc-secure/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
+	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'org.graalvm.buildtools.native' version '0.10.3'
 	id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-secure/pom.xml
+++ b/samples/grpc-secure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-server-netty-shaded/pom.xml
+++ b/samples/grpc-server-netty-shaded/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/samples/grpc-server/HELP-gradle.md
+++ b/samples/grpc-server/HELP-gradle.md
@@ -4,9 +4,9 @@
 For further reference, please consider the following sections:
 
 * [Official Gradle documentation](https://docs.gradle.org)
-* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/3.4.5/gradle-plugin)
-* [Create an OCI image](https://docs.spring.io/spring-boot/3.4.5/gradle-plugin/packaging-oci-image.html)
-* [GraalVM Native Image Support](https://docs.spring.io/spring-boot/3.4.5/reference/packaging/native-image/introducing-graalvm-native-images.html)
+* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/3.5.0/gradle-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.5.0/gradle-plugin/packaging-oci-image.html)
+* [GraalVM Native Image Support](https://docs.spring.io/spring-boot/3.5.0/reference/packaging/native-image/introducing-graalvm-native-images.html)
 * [Spring gRPC [Experimental]](https://docs.spring.io/spring-grpc/reference/index.html)
 
 ### Additional Links

--- a/samples/grpc-server/HELP-maven.md
+++ b/samples/grpc-server/HELP-maven.md
@@ -4,9 +4,9 @@
 For further reference, please consider the following sections:
 
 * [Official Apache Maven documentation](https://maven.apache.org/guides/index.html)
-* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/3.4.5/maven-plugin)
-* [Create an OCI image](https://docs.spring.io/spring-boot/3.4.5/maven-plugin/build-image.html)
-* [GraalVM Native Image Support](https://docs.spring.io/spring-boot/3.4.5/reference/packaging/native-image/introducing-graalvm-native-images.html)
+* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/3.5.0/maven-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.5.0/maven-plugin/build-image.html)
+* [GraalVM Native Image Support](https://docs.spring.io/spring-boot/3.5.0/reference/packaging/native-image/introducing-graalvm-native-images.html)
 * [Spring gRPC [Experimental]](https://docs.spring.io/spring-grpc/reference/index.html)
 
 ### Additional Links

--- a/samples/grpc-server/README.md
+++ b/samples/grpc-server/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"
 2022-12-08T05:32:25.377-08:00  WARN 551632 --- [           main] ocalVariableTableParameterNameDiscoverer : Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: net.devh.boot.grpc.server.autoconfigure.GrpcHealthServiceAutoConfiguration

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-tomcat-secure/README.md
+++ b/samples/grpc-tomcat-secure/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"

--- a/samples/grpc-tomcat-secure/build.gradle
+++ b/samples/grpc-tomcat-secure/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-tomcat-secure/pom.xml
+++ b/samples/grpc-tomcat-secure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-tomcat/README.md
+++ b/samples/grpc-tomcat/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"

--- a/samples/grpc-tomcat/build.gradle
+++ b/samples/grpc-tomcat/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-tomcat/pom.xml
+++ b/samples/grpc-tomcat/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-webflux/README.md
+++ b/samples/grpc-webflux/README.md
@@ -11,7 +11,7 @@ $ ./mvnw spring-boot:run
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::                (v3.4.5)
+ :: Spring Boot ::                (v3.5.0)
 
 2022-12-08T05:32:24.934-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : Starting DemoApplication using Java 17.0.5 with PID 551632 (/home/dsyer/dev/scratch/demo/target/classes started by dsyer in /home/dsyer/dev/scratch/demo)
 2022-12-08T05:32:24.938-08:00  INFO 551632 --- [           main] com.example.demo.DemoApplication         : No active profile set, falling back to 1 default profile: "default"

--- a/samples/grpc-webflux/build.gradle
+++ b/samples/grpc-webflux/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.graalvm.buildtools.native' version '0.10.3'
     id 'com.google.protobuf' version '0.9.4'

--- a/samples/grpc-webflux/pom.xml
+++ b/samples/grpc-webflux/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>

--- a/spring-grpc-build-dependencies/pom.xml
+++ b/spring-grpc-build-dependencies/pom.xml
@@ -49,10 +49,10 @@
 	</licenses>
 
 	<properties>
-		<spring-framework.version>6.2.6</spring-framework.version>
-		<spring-security.version>6.4.4</spring-security.version>
-		<micrometer.version>1.14.6</micrometer.version>
-		<netty.version>4.1.118.Final</netty.version>
+		<spring-framework.version>6.2.7</spring-framework.version>
+		<spring-security.version>6.5.0</spring-security.version>
+		<micrometer.version>1.15.0</micrometer.version>
+		<netty.version>4.1.121.Final</netty.version>
 		<spring-javaformat-maven-plugin.version>0.0.43</spring-javaformat-maven-plugin.version>
 	</properties>
 


### PR DESCRIPTION
This commit updates to Spring Boot 3.5.0 and also updates dependency versions that are specified by both spring-grpc and spring boot as follows:

- jackson from `2.17.2` to `2.19.0`
- junit from `5.10.5` to `5.12.2`
- spring-security from `6.2.6` to `6.4.4`
- micrometer from `1.14.6` to `1.15.0`
- netty from `4.1.118.Final` to `4.1.121.Final`