### PR TITLE
Add docs for inprocess server and channel factories

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -133,10 +133,11 @@ dependencies {
 
 [[in-process-channel]]
 == InProcess Channel
-You can communicate with an link:server.adoc#in-process-server[in-process server factory] (i.e. not listening on a network port) by including the `io.grpc.grpc-inprocess` dependency on your classpath.
+You can communicate with an link:server.adoc#in-process-server[in-process server] (i.e. not listening on a network port) by including the `io.grpc.grpc-inprocess` dependency on your classpath.
 
 In this mode, the in-process channel factory is auto-configured in *addition* to the regular channel factories (e.g. Netty).
-However, to prevent users from having to deal with multiple channel factory, a composite channel factory has been introduced which consults its composed factories to find the first one that supports the channel target.
+However, to prevent users from having to deal with multiple channel factories, a composite channel factory is configured as the primary channel factory bean.
+The composite consults its composed factories to find the first one that supports the channel target.
 
 NOTE: To use the inprocess server the channel target must be set to `in-process://<in-process-name>`
 

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -131,6 +131,17 @@ dependencies {
 }
 ----
 
+[[in-process-channel]]
+== InProcess Channel
+You can communicate with an link:server.adoc#in-process-server[in-process server factory] (i.e. not listening on a network port) by including the `io.grpc.grpc-inprocess` dependency on your classpath.
+
+In this mode, the in-process channel factory is auto-configured in *addition* to the regular channel factories (e.g. Netty).
+However, to prevent users from having to deal with multiple channel factory, a composite channel factory has been introduced which consults its composed factories to find the first one that supports the channel target.
+
+NOTE: To use the inprocess server the channel target must be set to `in-process://<in-process-name>`
+
+To disable the inprocess channel factory, you can set the `spring.grpc.client.inprocess.enabled` property to false.
+
 == Channel Configuration
 The channel factory provides an API to create channels.
 The channel creation process can be configured as follows.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -92,6 +92,16 @@ The native gRPC server (with netty etc.) will run happily inside a web applicati
 If you want to do that in any Spring Boot application, it should be sufficient *not* to include the `grpc-servlet-jakarta` dependency on your classpath.
 This dependency is only provided by the `spring-grpc-server-web-spring-boot-starter` (or if you include it explicitly yourself), but if you need to be explicit you can set `spring.grpc.server.servlet.enabled=false` in your application configuration.
 
+[[in-process-server]]
+== InProcess Server
+
+You can run an in-process server (i.e. not listening on a network port) by including the `io.grpc.grpc-inprocess` dependency on your classpath and specifying the `spring.grpc.server.inprocess.name` property which is used as the identity of the server for clients to connect to.
+
+In this mode, the in-process server factory is auto-configured in *addition* to the regular server factory (e.g. Netty).
+
+NOTE: To use the inprocess server the channel target must be set to `in-process://<in-process-name>`
+
+
 [[server-interceptor]]
 == Server Interceptors
 
@@ -159,7 +169,10 @@ A `GrpcExceptionHandler` can be used to handle exceptions of a specific type, re
 
 If you include `spring-grpc-test` in your project, your gRPC server in a `@SpringBootTest` can be started in-process (i.e. not listening on a network port) by enabling the in-process server.
 All clients that connect to any server via the autoconfigured `GrpcChannelFactory` will be able to connect to it.
-You can switch the in-process server on by setting `spring.grpc.inprocess.enabled` to `true` or by adding the `@AutoConfigureInProcessTransport` annotation to your `@SpringBootTest` class.
+You can switch the in-process server on by setting `spring.grpc.test.inprocess.enabled` to `true` or by adding the `@AutoConfigureInProcessTransport` annotation to your `@SpringBootTest` class.
+
+NOTE: When the in-process server is run in test mode (as opposed to <<in-process-server,running normally>>) it replaces the regular server and channel factories (e.g. Netty)
+
 
 == Security
 


### PR DESCRIPTION
This is a first pass at the docs for the in-process support. My intent was to capture the key pieces outlined in the [original PR description](https://github.com/spring-projects/spring-grpc/pull/187#issue-3092034941).

Resolves #144 

@Meijuh @dsyer PTAL 