### PR TITLE
Add docs client interceptor filter

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -242,7 +242,23 @@ ClientInterceptor globalExtraThingsInterceptor() {
 }
 ----
 
-In the preceding example, the `globalLoggingInterceptor` customizer is applied prior to the `globalExtraThingsInterceptor`.
+In the preceding example, the `globalLoggingInterceptor` is applied prior to the `globalExtraThingsInterceptor`.
+
+[[global-client-interceptor-filtering]]
+==== Filtering
+All global interceptors are applied to all created channels by default.
+However, you can register a `ClientInterceptorFilter` bean to decide which interceptors are applied to which channel factories.
+
+The following example prevents the `ExtraThingsInterceptor` interceptor from being applied to any channels created by the `InProcessGrpcChannelFactory` channel factory.
+
+[source,java]
+----
+@Bean
+ClientInterceptorFilter myInterceptorFilter() {
+    return (interceptor, factory) -> !(interceptor instanceof ExtraThingsInterceptor
+            && factory instanceof InProcessGrpcChannelFactory);
+}
+----
 
 === Per-Channel
 To add one or more client interceptors to be applied to a single client channel you can simply set the interceptor instance(s) on the options passed to the channel factory when creating the channel.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -16,10 +16,13 @@
 |spring.grpc.client.default-channel.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the channel (default 8KiB). Set to '-1' to use the highest possible limit (not recommended).
 |spring.grpc.client.default-channel.negotiation-type | `+++plaintext+++` | The negotiation type for the channel.
 |spring.grpc.client.default-channel.secure | `+++true+++` | Flag to say that strict SSL checks are not enabled (so the remote certificate could be anonymous).
+|spring.grpc.client.default-channel.service-config |  | Map representation of the service config to use for the channel
 |spring.grpc.client.default-channel.ssl.bundle |  | SSL bundle name.
 |spring.grpc.client.default-channel.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
 |spring.grpc.client.default-channel.user-agent |  | The custom User-Agent for the channel.
 |spring.grpc.client.enabled | `+++true+++` | Whether to enable client autoconfiguration.
+|spring.grpc.client.inprocess.enabled | `+++true+++` | Whether to configure the in-process channel factory.
+|spring.grpc.client.inprocess.exclusive | `+++true+++` | Whether the inprocess channel factory should be the only channel factory available. When the value is true, no other channel factory will be configured.
 |spring.grpc.client.observations.enabled | `+++true+++` | Whether to enable Observations on the client.
 |spring.grpc.server.address |  | The address to bind to. could be a host:port combination or a pseudo URL like static://host:port. Can not be set if host or port are set independently.
 |spring.grpc.server.enabled | `+++true+++` | Whether to enable server autoconfiguration.
@@ -31,6 +34,8 @@
 |spring.grpc.server.health.actuator.update-rate | `+++5s+++` | How often to update the health status.
 |spring.grpc.server.health.enabled | `+++true+++` | Whether to auto-configure Health feature on the gRPC server.
 |spring.grpc.server.host | `+++*+++` | Server address to bind to. The default is any IP address ('*').
+|spring.grpc.server.inprocess.exclusive |  | Whether the inprocess server factory should be the only server factory available. When the value is true no other server factory will be configured.
+|spring.grpc.server.inprocess.name |  | The name of the in-process server or null to not start the in-process server.
 |spring.grpc.server.keep-alive.max-age |  | Maximum time a connection may exist before being gracefully terminated (default infinite).
 |spring.grpc.server.keep-alive.max-age-grace |  | Maximum time for graceful connection termination (default infinite).
 |spring.grpc.server.keep-alive.max-idle |  | Maximum time a connection can remain idle before being gracefully terminated (default infinite).

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientProperties.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientProperties.java
@@ -150,12 +150,11 @@ public class GrpcClientProperties implements EnvironmentAware, VirtualTargets {
 			return this.health;
 		}
 
+		/**
+		 * Map representation of the service config to use for the channel
+		 */
 		private final Map<String, ?> serviceConfig = new HashMap<>();
 
-		/**
-		 * The service config to use for the channel.
-		 * @return the service config
-		 */
 		public Map<String, ?> getServiceConfig() {
 			return this.serviceConfig;
 		}


### PR DESCRIPTION
Adds section on how to use the `ClientInterceptorFIlter`.

<img width="1106" alt="Screenshot 2025-06-23 at 15 08 47" src="https://github.com/user-attachments/assets/42bb179a-a93c-4ad0-b402-8d0430e339b0" />

@therepanic PTAL