### PR TITLE
Add docs for grpc-services dependency

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/health.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/health.adoc
@@ -5,6 +5,8 @@
 Spring gRPC autoconfigures the standard https://grpc.io/docs/guides/health-checking/[gRPC Health service] for performing health check calls against gRPC servers.
 The health service is registered with the gRPC server and a `HealthStatusManager` bean is provided that can be used to update the health status of your services.
 
+IMPORTANT: The health service resides in the `io.grpc:grpc-services` library which is marked as `optional` by Spring gRPC. You must add this dependency to your application in order for it to be autoconfigured.
+
 == Actuator Health
 When Spring Boot Actuator is added to your project and the {spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health[Health endpoint] is available, the framework will automatically periodically update the health status of a configured list of Spring Boot {spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health.auto-configured-health-indicators[health indicators], including any ({spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health.writing-custom-health-indicators[custom indicators]).
 By default, the aggregate status of the individual indicators is also used to update the overall server status (`""`).

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -8,7 +8,7 @@ The `Server` is the gRPC server that listens for incoming requests and routes th
 == Create a gRPC Service
 
 To create a gRPC server, you need to provide one or more beans of type `BindableService`.
-There are some `BindableServices` available off the shelf that you could include in your application (an example is the reflection service from the `grpc-services` artifact which allows clients to browse the metadata of your services and download the Protobuf files).
+There are some `BindableServices` available off the shelf that you could include in your application (e.g. the <<reflection-service,gRPC Reflection>> or <<health-service,gRPC Health>> services).
 Very commonly, you will create your own `BindableService` by extending the generated service implementation from your Protobuf file.
 The easiest way to activate it is to simply add a Spring `@Service` annotation to the implementation class and have it picked up by the `@ComponentScan` in your Spring Boot application.
 
@@ -150,7 +150,14 @@ However, by setting the `blendWithGlobalInterceptors` attribute on the `@GrpcSer
 You can use this option if you want to add a per-service interceptor between global interceptors.
 ====
 
-[[health]]
+[[reflection-service]]
+== Reflection
+
+Spring gRPC autoconfigures the standard https://grpc.io/docs/guides/reflection/[gRPC Reflection service] which allows clients to browse the metadata of your services and download the Protobuf files.
+
+IMPORTANT: The reflection service resides in the `io.grpc:grpc-services` library which is marked as `optional` by Spring gRPC. You must add this dependency to your application in order for it to be autoconfigured.
+
+[[health-service]]
 include::health.adoc[leveloffset=+1]
 
 == Observability


### PR DESCRIPTION
Clarifies in the docs that the grpc-services dependency is needed for health and reflection services to be autoconfigured.

Resolves #189 

I also added a section for the reflection service to clarify the same. @lobaorn-bitso PTAL 

<img width="1126" alt="Screenshot 2025-06-23 at 17 19 55" src="https://github.com/user-attachments/assets/ee84231e-08ec-4079-bab7-db593e53ae53" />
