### PR TITLE
Split service discoverer and configurer

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
 
 /**
- * Default {@link GrpcServiceConfigurer} that binds and configures services with
- * interceptors.
+ * Default {@link GrpcServiceConfigurer} implementation that binds and configures services
+ * with interceptors.
  *
  * @author Chris Bono
  */
@@ -52,8 +52,8 @@ public class DefaultGrpcServiceConfigurer implements GrpcServiceConfigurer, Init
 	}
 
 	@Override
-	public ServerServiceDefinition configure(BindableService bindableService, @Nullable GrpcServiceInfo serviceInfo) {
-		return bindInterceptors(bindableService, serviceInfo);
+	public ServerServiceDefinition configure(ServerServiceDefinitionSpec serviceDefinitionSpec) {
+		return bindInterceptors(serviceDefinitionSpec.service(), serviceDefinitionSpec.serviceInfo());
 	}
 
 	private List<ServerInterceptor> findGlobalInterceptors() {

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceDiscoverer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceDiscoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,44 +18,26 @@ package org.springframework.grpc.server.service;
 
 import java.util.List;
 
-import io.grpc.ServerServiceDefinition;
-
 /**
- * Discovers {@link ServerServiceDefinition gRPC services} to be provided by the server.
+ * Discovers gRPC services to be provided by the server.
  *
  * @author Michael (yidongnan@gmail.com)
  * @author Chris Bono
  */
-@FunctionalInterface
 public interface GrpcServiceDiscoverer {
 
 	/**
-	 * Find gRPC services for the server to provide.
-	 * @return list of services to add to the server - empty when no services available
+	 * Find the specs of the available gRPC services. The spec can then be passed into a
+	 * {@link GrpcServiceConfigurer service configurer} to bind and configure an actual
+	 * service definition.
+	 * @return list of service specs - empty when no services available
 	 */
-	List<ServerServiceDefinition> findServices();
+	List<ServerServiceDefinitionSpec> findServices();
 
 	/**
-	 * Find gRPC service names.
+	 * Find the names of the available gRPC services.
 	 * @return list of service names - empty when no services available
 	 */
-	default List<String> listServiceNames() {
-		return findServices().stream()
-			.map(ServerServiceDefinition::getServiceDescriptor)
-			.map(descriptor -> descriptor.getName())
-			.toList();
-	}
-
-	/**
-	 * Find gRPC service.
-	 * @param name the service name
-	 * @return a service - null if no service has this name
-	 */
-	default ServerServiceDefinition findService(String name) {
-		return findServices().stream()
-			.filter(service -> service.getServiceDescriptor().getName().equals(name))
-			.findFirst()
-			.orElse(null);
-	}
+	List<String> listServiceNames();
 
 }

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/ServerServiceDefinitionSpec.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/ServerServiceDefinitionSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.grpc.server.service;
 
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
 
 /**
- * Configures and binds a {@link ServerServiceDefinitionSpec service spec} into a
- * {@link ServerServiceDefinition service definition} that can then be added to a gRPC
- * server.
+ * Encapsulates enough information to construct an actual {@link ServerServiceDefinition}.
  *
+ * @param service the bindable service
+ * @param serviceInfo optional additional information about the service (e.g.
+ * interceptors)
  * @author Chris Bono
  */
-@FunctionalInterface
-public interface GrpcServiceConfigurer {
-
-	/**
-	 * Configure and bind a gRPC service spec resulting in a service definition that can
-	 * then be added to a gRPC server.
-	 * @param serviceSpec the spec containing the info about the service
-	 * @return bound and configured service definition that is ready to be added to the
-	 * server
-	 */
-	ServerServiceDefinition configure(ServerServiceDefinitionSpec serviceSpec);
+public record ServerServiceDefinitionSpec(BindableService service, @Nullable GrpcServiceInfo serviceInfo) {
+	public ServerServiceDefinitionSpec {
+		Assert.notNull(service, "service must not be null");
+	}
 
 }

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurerTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurerTests.java
@@ -108,12 +108,13 @@ class DefaultGrpcServiceConfigurerTests {
 				.run((context) -> {
 					DefaultGrpcServiceConfigurer configurer = context.getBean(DefaultGrpcServiceConfigurer.class);
 					if (expectedExceptionType != null) {
-						assertThatThrownBy(() -> configurer.configure(service, serviceInfo))
+						assertThatThrownBy(
+								() -> configurer.configure(new ServerServiceDefinitionSpec(service, serviceInfo)))
 							.isInstanceOf(expectedExceptionType);
 						serverInterceptorsMocked.verifyNoInteractions();
 					}
 					else {
-						configurer.configure(service, serviceInfo);
+						configurer.configure(new ServerServiceDefinitionSpec(service, serviceInfo));
 						serverInterceptorsMocked
 							.verify(() -> ServerInterceptors.interceptForward(serviceDef, expectedInterceptors));
 					}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfiguration.java
@@ -23,15 +23,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration;
-import org.springframework.grpc.server.GrpcServerFactory;
 import org.springframework.grpc.server.ServerBuilderCustomizer;
 import org.springframework.grpc.server.exception.ReactiveStubBeanDefinitionRegistrar;
-import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
 import org.springframework.grpc.server.service.DefaultGrpcServiceConfigurer;
 import org.springframework.grpc.server.service.DefaultGrpcServiceDiscoverer;
 import org.springframework.grpc.server.service.GrpcServiceConfigurer;
@@ -78,9 +75,8 @@ public class GrpcServerAutoConfiguration {
 
 	@ConditionalOnMissingBean(GrpcServiceDiscoverer.class)
 	@Bean
-	DefaultGrpcServiceDiscoverer grpcServiceDiscoverer(GrpcServiceConfigurer grpcServiceConfigurer,
-			ApplicationContext applicationContext) {
-		return new DefaultGrpcServiceDiscoverer(grpcServiceConfigurer, applicationContext);
+	DefaultGrpcServiceDiscoverer grpcServiceDiscoverer(ApplicationContext applicationContext) {
+		return new DefaultGrpcServiceDiscoverer(applicationContext);
 	}
 
 	@ConditionalOnBean(CompressorRegistry.class)

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.grpc.server.ServerBuilderCustomizer;
 import org.springframework.grpc.server.ShadedNettyGrpcServerFactory;
 import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
 import org.springframework.grpc.server.service.DefaultGrpcServiceConfigurer;
+import org.springframework.grpc.server.service.DefaultGrpcServiceDiscoverer;
 import org.springframework.grpc.server.service.GrpcServiceConfigurer;
 import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
 
@@ -148,9 +149,7 @@ class GrpcServerAutoConfigurationTests {
 		this.contextRunnerWithLifecyle()
 			.withPropertyValues("spring.grpc.server.port=0")
 			.run((context) -> assertThat(context).getBean(GrpcServiceDiscoverer.class)
-				.extracting(GrpcServiceDiscoverer::findServices,
-						InstanceOfAssertFactories.list(ServerServiceDefinition.class))
-				.containsExactly(this.serviceDefinition));
+				.isInstanceOf(DefaultGrpcServiceDiscoverer.class));
 	}
 
 	@Test

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/health/GrpcServerHealthAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/health/GrpcServerHealthAutoConfigurationTests.java
@@ -39,6 +39,7 @@ import org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfig
 import org.springframework.grpc.autoconfigure.server.ServerBuilderCustomizers;
 import org.springframework.grpc.autoconfigure.server.health.GrpcServerHealthAutoConfiguration.ActuatorHealthAdapterConfiguration;
 import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
+import org.springframework.grpc.server.service.GrpcServiceConfigurer;
 import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
 import org.springframework.util.StringUtils;
 
@@ -130,6 +131,7 @@ class GrpcServerHealthAutoConfigurationTests {
 			.withBean("noopServerLifecycle", GrpcServerLifecycle.class, Mockito::mock)
 			.withBean("serverBuilderCustomizers", ServerBuilderCustomizers.class, Mockito::mock)
 			.withBean("grpcServicesDiscoverer", GrpcServiceDiscoverer.class, Mockito::mock)
+			.withBean("grpcServiceConfigurer", GrpcServiceConfigurer.class, Mockito::mock)
 			.withBean("sslBundles", SslBundles.class, Mockito::mock)
 			.withPropertyValues("spring.grpc.server.port=0")
 			.run((context) -> assertThatBeanDefinitionsContainInOrder(context, GrpcServerHealthAutoConfiguration.class,

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/security/GrpcReactiveRequestTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/security/GrpcReactiveRequestTests.java
@@ -46,8 +46,7 @@ public class GrpcReactiveRequestTests {
 		ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("my-service").build();
 		when(service.bindService()).thenReturn(serviceDefinition);
 		this.context.registerBean(BindableService.class, () -> service);
-		this.context.registerBean(GrpcServiceDiscoverer.class,
-				() -> new DefaultGrpcServiceDiscoverer((input, info) -> input.bindService(), context));
+		this.context.registerBean(GrpcServiceDiscoverer.class, () -> new DefaultGrpcServiceDiscoverer(context));
 	}
 
 	@Test
@@ -63,7 +62,7 @@ public class GrpcReactiveRequestTests {
 		return request;
 	}
 
-	static interface MockService extends BindableService {
+	interface MockService extends BindableService {
 
 	}
 

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/security/GrpcServletRequestTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/security/GrpcServletRequestTests.java
@@ -42,8 +42,7 @@ public class GrpcServletRequestTests {
 		ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("my-service").build();
 		when(service.bindService()).thenReturn(serviceDefinition);
 		this.context.registerBean(BindableService.class, () -> service);
-		this.context.registerBean(GrpcServiceDiscoverer.class,
-				() -> new DefaultGrpcServiceDiscoverer((input, info) -> input.bindService(), context));
+		this.context.registerBean(GrpcServiceDiscoverer.class, () -> new DefaultGrpcServiceDiscoverer(context));
 	}
 
 	@Test
@@ -51,28 +50,28 @@ public class GrpcServletRequestTests {
 		GrpcServletRequestMatcher matcher = GrpcServletRequest.all();
 		MockHttpServletRequest request = mockRequest("/my-service/Method");
 		assertThat(matcher.matches(request)).isTrue();
-	};
+	}
 
 	@Test
 	void noMatch() {
 		GrpcServletRequestMatcher matcher = GrpcServletRequest.all();
 		MockHttpServletRequest request = mockRequest("/other-service/Method");
 		assertThat(matcher.matches(request)).isFalse();
-	};
+	}
 
 	@Test
 	void requestMatcherExcludes() {
 		GrpcServletRequestMatcher matcher = GrpcServletRequest.all().excluding("my-service");
 		MockHttpServletRequest request = mockRequest("/my-service/Method");
 		assertThat(matcher.matches(request)).isFalse();
-	};
+	}
 
 	@Test
 	void noServices() {
 		GrpcServletRequestMatcher matcher = GrpcServletRequest.all();
 		MockHttpServletRequest request = mockRequestNoServices("/my-service/Method");
 		assertThat(matcher.matches(request)).isFalse();
-	};
+	}
 
 	private MockHttpServletRequest mockRequestNoServices(String path) {
 		MockServletContext servletContext = new MockServletContext();
@@ -91,7 +90,7 @@ public class GrpcServletRequestTests {
 		return request;
 	}
 
-	static interface MockService extends BindableService {
+	interface MockService extends BindableService {
 
 	}
 

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessTestAutoConfiguration.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessTestAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.grpc.client.InProcessGrpcChannelFactory;
 import org.springframework.grpc.server.InProcessGrpcServerFactory;
 import org.springframework.grpc.server.ServerBuilderCustomizer;
 import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
+import org.springframework.grpc.server.service.GrpcServiceConfigurer;
 import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
 
 import io.grpc.BindableService;
@@ -53,10 +54,11 @@ public class InProcessTestAutoConfiguration {
 	@Bean
 	@ConditionalOnBean(BindableService.class)
 	@Order(Ordered.HIGHEST_PRECEDENCE)
-	TestInProcessGrpcServerFactory testInProcessGrpcServerFactory(GrpcServiceDiscoverer grpcServicesDiscoverer,
+	TestInProcessGrpcServerFactory testInProcessGrpcServerFactory(GrpcServiceDiscoverer serviceDiscoverer,
+			GrpcServiceConfigurer serviceConfigurer,
 			List<ServerBuilderCustomizer<InProcessServerBuilder>> customizers) {
 		var factory = new TestInProcessGrpcServerFactory(address, customizers);
-		grpcServicesDiscoverer.findServices().forEach(factory::addService);
+		serviceDiscoverer.findServices().stream().map(serviceConfigurer::configure).forEach(factory::addService);
 		return factory;
 	}
 


### PR DESCRIPTION
This commit simplifies the DefaultGrpcServiceDiscoverer by removing its dependence on the DefaultGrpcServiceConfigurer. Now the expectation is the discoverer returns a spec of the service definition rather than a bound service. The configurer then accepts that spec and binds and configures it.

See #208