### PR TITLE
Drop old 'jakarta_omit' option

### DIFF
--- a/samples/grpc-client/build.gradle
+++ b/samples/grpc-client/build.gradle
@@ -51,7 +51,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-client/pom.xml
+++ b/samples/grpc-client/pom.xml
@@ -113,7 +113,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-oauth2/build.gradle
+++ b/samples/grpc-oauth2/build.gradle
@@ -61,7 +61,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-oauth2/pom.xml
+++ b/samples/grpc-oauth2/pom.xml
@@ -124,7 +124,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-reactive/build.gradle
+++ b/samples/grpc-reactive/build.gradle
@@ -62,7 +62,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
             reactor {}

--- a/samples/grpc-reactive/pom.xml
+++ b/samples/grpc-reactive/pom.xml
@@ -139,7 +139,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 					<jvmMavenPlugins>

--- a/samples/grpc-secure/build.gradle
+++ b/samples/grpc-secure/build.gradle
@@ -54,7 +54,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-secure/pom.xml
+++ b/samples/grpc-secure/pom.xml
@@ -117,7 +117,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-server-kotlin/build.gradle
+++ b/samples/grpc-server-kotlin/build.gradle
@@ -68,7 +68,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
             grpckt {

--- a/samples/grpc-server-kotlin/pom.xml
+++ b/samples/grpc-server-kotlin/pom.xml
@@ -151,7 +151,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 					<jvmMavenPlugins>
@@ -162,7 +162,7 @@
 							<classifier>jdk8</classifier>
 							<type>jar</type>
 							<mainClass>io.grpc.kotlin.generator.GeneratorRunner</mainClass>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</jvmMavenPlugin>
 					</jvmMavenPlugins>
 				</configuration>

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -59,7 +59,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-server-netty-shaded/pom.xml
+++ b/samples/grpc-server-netty-shaded/pom.xml
@@ -114,7 +114,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -55,7 +55,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -120,7 +120,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-tomcat-secure/build.gradle
+++ b/samples/grpc-tomcat-secure/build.gradle
@@ -55,7 +55,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-tomcat-secure/pom.xml
+++ b/samples/grpc-tomcat-secure/pom.xml
@@ -112,7 +112,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-tomcat/build.gradle
+++ b/samples/grpc-tomcat/build.gradle
@@ -55,7 +55,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-tomcat/pom.xml
+++ b/samples/grpc-tomcat/pom.xml
@@ -117,7 +117,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>

--- a/samples/grpc-webflux/build.gradle
+++ b/samples/grpc-webflux/build.gradle
@@ -54,7 +54,6 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {
-                option 'jakarta_omit'
                 option '@generated=omit'
             }
         }

--- a/samples/grpc-webflux/pom.xml
+++ b/samples/grpc-webflux/pom.xml
@@ -112,7 +112,7 @@
 							<groupId>io.grpc</groupId>
 							<artifactId>protoc-gen-grpc-java</artifactId>
 							<version>${grpc.version}</version>
-							<options>jakarta_omit,@generated=omit</options>
+							<options>@generated=omit</options>
 						</binaryMavenPlugin>
 					</binaryMavenPlugins>
 				</configuration>


### PR DESCRIPTION
The `jakarta_option` was only supported by a single grpc-java release and quickly replaced by `@generated=omit` (https://github.com/grpc/grpc-java/pull/11086), which is already used by the sample configurations.