### PR TITLE
Avoid NPE when merging null trailers in `GrpcExceptionHandledServerCall`

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandledServerCall.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandledServerCall.java
@@ -36,7 +36,10 @@ public class GrpcExceptionHandledServerCall<ReqT, RespT>
 		if (status.getCode() == Status.Code.UNKNOWN && status.getCause() != null) {
 			final Throwable cause = status.getCause();
 			final StatusException statusException = this.exceptionHandler.handleException(cause);
-			trailers.merge(statusException.getTrailers());
+			Metadata statusExceptionTrailers = statusException.getTrailers();
+			if (statusExceptionTrailers != null) {
+				trailers.merge(statusExceptionTrailers);
+			}
 			super.close(statusException.getStatus(), trailers);
 		}
 		else {


### PR DESCRIPTION
Closes: gh-229