### PR TITLE
Remove maven.compiler.source and maven.compiler.target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- internal dependencies -->
 		<spring-boot.version>3.5.4</spring-boot.version>


### PR DESCRIPTION
`maven.compiler.source` and `maven.compiler.target` have been superseded by `maven.compiler.release` (see [here](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html)), which is already set in the `maven-compiler-plugin` configuration of this project.