### PR TITLE
Fix Observation property name in `_configprops.adoc`

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -23,7 +23,7 @@
 |spring.grpc.client.enabled | `+++true+++` | Whether to enable client autoconfiguration.
 |spring.grpc.client.inprocess.enabled | `+++true+++` | Whether to configure the in-process channel factory.
 |spring.grpc.client.inprocess.exclusive | `+++true+++` | Whether the inprocess channel factory should be the only channel factory available. When the value is true, no other channel factory will be configured.
-|spring.grpc.client.observations.enabled | `+++true+++` | Whether to enable Observations on the client.
+|spring.grpc.client.observation.enabled | `+++true+++` | Whether to enable Observations on the client.
 |spring.grpc.server.address |  | The address to bind to. could be a host:port combination or a pseudo URL like static://host:port. Can not be set if host or port are set independently.
 |spring.grpc.server.enabled | `+++true+++` | Whether to enable server autoconfiguration.
 |spring.grpc.server.exception-handling.enabled | `+++true+++` | Whether to enable user-defined global exception handling on the gRPC server.
@@ -45,7 +45,7 @@
 |spring.grpc.server.keep-alive.timeout | `+++20s+++` | Maximum time to wait for read activity after sending a keep alive ping. If sender does not receive an acknowledgment within this time, it will close the connection (default 20s).
 |spring.grpc.server.max-inbound-message-size | `+++4194304B+++` | Maximum message size allowed to be received by the server (default 4MiB).
 |spring.grpc.server.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the server (default 8KiB).
-|spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
+|spring.grpc.server.observation.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
 |spring.grpc.server.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -36,7 +36,7 @@
       "defaultValue": true
     },
     {
-      "name": "spring.grpc.server.observations.enabled",
+      "name": "spring.grpc.server.observation.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Observations on the server.",
       "defaultValue": true
@@ -60,7 +60,7 @@
       "defaultValue": true
     },
     {
-      "name": "spring.grpc.client.observations.enabled",
+      "name": "spring.grpc.client.observation.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Observations on the client.",
       "defaultValue": true


### PR DESCRIPTION
In fact, this inaccuracy has been described since the time when the autoconfigure module was in spring-grpc. I think we should consider using the `observation` option, although both options are fine, but this option is older and more familiar to use (spring grpc 1.0.0 has not been released yet, but nevertheless). In addition, I think that the original intention was to use the `observation` option. Furthermore, there are already options in the Spring ecosystem that simply use `observation`, such as `spring.kafka.listener.observation-enabled`.

Closes: gh-269